### PR TITLE
Feature: Auto-trigger credential backup after enrollment (Issue #3)

### DIFF
--- a/VettID/Features/Backup/BackupSettingsView.swift
+++ b/VettID/Features/Backup/BackupSettingsView.swift
@@ -51,9 +51,18 @@ struct BackupSettingsView: View {
 
     private var settingsForm: some View {
         Form {
-            // Automatic backup section
-            Section("Automatic Backup") {
-                Toggle("Enable Auto-Backup", isOn: $viewModel.settings.autoBackupEnabled)
+            // Automatic backup section - prominent opt-out toggle
+            Section {
+                Toggle(isOn: $viewModel.settings.autoBackupEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Automatic Backups")
+                            .font(.body)
+                        Text(viewModel.settings.autoBackupEnabled ? "Enabled" : "Disabled")
+                            .font(.caption)
+                            .foregroundColor(viewModel.settings.autoBackupEnabled ? .green : .secondary)
+                    }
+                }
+                .tint(.green)
 
                 if viewModel.settings.autoBackupEnabled {
                     Picker("Frequency", selection: $viewModel.settings.backupFrequency) {
@@ -70,6 +79,11 @@ struct BackupSettingsView: View {
 
                     Toggle("WiFi Only", isOn: $viewModel.settings.wifiOnly)
                 }
+            } header: {
+                Text("Automatic Backup")
+            } footer: {
+                Text("Backups are enabled by default to protect your credentials. You can disable automatic backups here, but this is not recommended.")
+                    .foregroundColor(viewModel.settings.autoBackupEnabled ? .secondary : .orange)
             }
 
             // Content section

--- a/VettID/Features/Vault/VaultBackgroundRefresh.swift
+++ b/VettID/Features/Vault/VaultBackgroundRefresh.swift
@@ -409,10 +409,30 @@ extension VaultBackgroundRefresh {
         }
     }
 
-    /// Call after successful enrollment to start background sync
+    /// Call after successful enrollment to start background sync and trigger initial backup
     func onEnrollmentComplete() {
         scheduleAllTasks()
         Self.logger.info("Scheduled background tasks after enrollment")
+
+        // Trigger automatic credential backup after enrollment
+        Task {
+            await triggerInitialBackup()
+        }
+    }
+
+    /// Trigger initial backup after enrollment
+    /// Backs up the Protean Credential and schedules automatic backups
+    private func triggerInitialBackup() async {
+        Self.logger.info("Triggering initial backup after enrollment")
+
+        // Schedule automatic backups with default settings (enabled by default)
+        let defaultSettings = BackupSettings()
+        BackupBackgroundTask.shared.schedule(settings: defaultSettings)
+        Self.logger.info("Scheduled automatic backups after enrollment")
+
+        // Note: The Protean Credential is already backed up during enrollment
+        // in EnrollmentService.storeAndBackupProteanCredential()
+        // This just ensures automatic backups are scheduled going forward
     }
 
     /// Call on logout to stop background sync

--- a/VettIDUITests/EnrollmentUITests.swift
+++ b/VettIDUITests/EnrollmentUITests.swift
@@ -24,6 +24,11 @@ final class EnrollmentUITests: VettIDUITests {
         let enterCodeButton = app.buttons["Enter code manually"]
         XCTAssertTrue(enterCodeButton.exists, "Enter code button should be visible")
         XCTAssertTrue(enterCodeButton.isEnabled, "Enter code button should be enabled")
+
+        // Verify recovery button (added for Issue #2)
+        let recoverButton = app.buttons["Recover existing account"]
+        XCTAssertTrue(recoverButton.exists, "Recover account button should be visible")
+        XCTAssertTrue(recoverButton.isEnabled, "Recover account button should be enabled")
     }
 
     func testTapScanQRCodeNavigatesToScanner() throws {


### PR DESCRIPTION
## Summary

- Auto-triggers credential backup scheduling after enrollment completes
- Updates BackupSettingsView with prominent opt-out toggle and explanatory text

## Changes

### VaultBackgroundRefresh.swift
- Added `triggerInitialBackup()` method called from `onEnrollmentComplete()`
- Schedules automatic backups with default settings (enabled) after enrollment
- Note: Protean Credential is already backed up during enrollment in `EnrollmentService.storeAndBackupProteanCredential()`

### BackupSettingsView.swift
- Updated Automatic Backup section with prominent toggle:
  - Clear "Automatic Backups" label with enabled/disabled status indicator
  - Green tint when enabled
  - Explanatory footer: "Backups are enabled by default to protect your credentials..."
  - Orange warning color when backups are disabled

### EnrollmentUITests.swift
- Added assertion for "Recover existing account" button on welcome screen (from Issue #2)

## Test plan
- [x] Build succeeds
- [x] `testWelcomeScreenDisplaysCorrectly` test passes
- [ ] Manual test: Verify backup is scheduled after new enrollment
- [ ] Manual test: Verify opt-out toggle is visible with explanatory text
- [ ] Manual test: Verify disabling auto-backup shows warning text in orange

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)